### PR TITLE
Add check-stack-names as pre-commit-hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,10 @@
 -   id: compare-stack-and-file-names
-    name: Stack name linter
+    name: Stack and file name linter
     description: "Ensure that all stacks have names consistent with their config filenames"
     entry: compare-stack-and-file-names
+    language: python
+-   id: check-stack-names
+    name: Stack name linter
+    description: "Ensure that all stacks have valid names"
+    entry: check-stack-names
     language: python


### PR DESCRIPTION
The previous PR (#3) had a command that lints stack names appropriately, but it had not been added to `.pre-commit-hooks.yaml`. This PR adds it to that file, and should make it installable through the normal method of adding it to the `.pre-commit-config.yaml` file for a project.