### PR TITLE
[IT-1531] Add a check for stack_tags

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,8 @@
     description: "Ensure that all stacks have valid names"
     entry: check-stack-names
     language: python
+-   id: check-stack-tags
+    name: Stack tags linter
+    description: "Ensure that all stacks are tagged"
+    entry: check-stack-tags
+    language: python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This repo contains scripts for the purpose of pre-commit processing
-(e.g. linting) of Sceptre templates.
+(e.g. linting) of Sceptre config files.
 
 ## Installation 
 
@@ -17,9 +17,11 @@ It will process files ending in `.yaml` under the
 attempt to parse the result (as YAML files) and check that the value
 of the `stack_name` matches the file name (minus `.yaml`).
 
-* `check-stack-names` Checks for valid stack names in templates.  Valid
+* `check-stack-names` Checks for valid stack names in sceptre configs.  Valid
 stack names are [constraints specified by
 CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html)
+
+* `check-stack-tags` Checks for 'stack_tags' definition in sceptre configs.
 
 Currently, no arguments or other parameters can be passed to these linters.
 
@@ -33,8 +35,9 @@ Running scripts:
 - 'bar bucket' is an invalid stack name (in './config/prod/s3.yaml')
 ```
 __NOTE__: A stack name can contain only alphanumeric characters (case-sensitive) and hyphens.
-It must start with an alphabetic character and can't be longer than 128 characters.
-https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
+It must start with an alphabetic character and can't be longer than 128 characters. For more
+details refer to the [AWS documentation](
+https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html)
 
 ```shell script
 ➜ compare-stack-and-file-names ./config/prod/*.yaml
@@ -50,6 +53,7 @@ by including the following in `.pre-commit-config.yaml`:
     hooks:
     -    id: compare-stack-and-file-names
     -    id: check-stack-names
+    -    id: check-stack-tags
 ```
 replacing `INSERT_VERSION` with a version tag or commit SHA-1.
 

--- a/linters/check_stack_tags.py
+++ b/linters/check_stack_tags.py
@@ -1,0 +1,20 @@
+import re
+import sys
+from .utils import load_config, get_new_config_paths
+
+
+def check_stack_tags():
+    """Look in command-line arguments for sceptre config files. Check that each
+    file sets `stack_tags`
+    """
+    all_new_paths = sys.argv[1:]
+    new_config_paths = get_new_config_paths(all_new_paths)
+
+    return_code = 0
+    for path in new_config_paths:
+        config = load_config(path)
+        if 'stack_tags' not in config:
+            print("- Missing stack_tags key in '%s'" % (path))
+            return_code = 1
+
+    sys.exit(return_code)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'compare-stack-and-file-names = linters.check_file_names:compare_file_and_stack_names',
-            'check-stack-names = linters.check_stack_names:check_stack_names'
+            'check-stack-names = linters.check_stack_names:check_stack_names',
+            'check-stack-tags = linters.check_stack_tags:check_stack_tags'
         ]
     },
     python_requires = '>=3.6'


### PR DESCRIPTION
Add a pre-commit hook to make sure users define `stack_tags` in
sceptre configs files.  The idea is to use this in the scicomp provisioner
to require users to define tags when provisioning AWS resources.