### PR TITLE
Update Jinja

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gitpython>=3.1.7,<4
-pyyaml>=5.3.1,<6
-Jinja2>=2.11.2,<3
+gitpython>=3.1,<4
+pyyaml>=6.0,<7
+Jinja2>=3.0,<4

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ with open('README.md', 'r') as fh:
 
 install_requirements = [
     'gitpython>=3.1,<4',
-    'pyyaml>=5.3.1,<6',
-    'Jinja2>=2.11.2,<3',
+    'pyyaml>=6.0,<7',
+    'Jinja2>=3.0,<4',
 ]
 
 setuptools.setup(


### PR DESCRIPTION
An update to MarkUpSafe[1] breaks Jinja2 ver 2.x.  The fix is to update to
Jinja2 ver 3.x

[1] https://github.com/pallets/jinja/issues/1585